### PR TITLE
fix: add name to dialect

### DIFF
--- a/airtabledb/dialect.py
+++ b/airtabledb/dialect.py
@@ -50,6 +50,8 @@ def extract_query_host(
 
 
 class APSWAirtableDialect(APSWDialect):
+    name = "airtable"
+
     supports_statement_cache = True
 
     def __init__(


### PR DESCRIPTION
The name of the `APSWAirtableDialect` dialect is set to `shillelagh`, so it doesn't show up in the Superset database dropdown:

<img width="486" alt="Screenshot 2024-09-06 at 2 13 13 PM" src="https://github.com/user-attachments/assets/cf2a57fc-2e0d-40e3-8deb-ec4e99a1a628">

With the change:

<img width="486" alt="Screenshot 2024-09-06 at 2 14 53 PM" src="https://github.com/user-attachments/assets/df0ea4de-e091-4c89-b8d5-de7dd8e4e9fa">
